### PR TITLE
added uri for proxy and ffmpeg for transcoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN go get -d ./... \
  && go install
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates python3 py3-pip \
- && pip3 install youtube-dl \
- && apk del py3-pip
+RUN apk --no-cache add ca-certificates python3 py3-pip ffmpeg \
+&& pip3 install --disable-pip-version-check youtube-dl \
+&& apk del py3-pip 
 WORKDIR /root/
 COPY --from=0 /go/bin/yt2pod /usr/local/bin/
 CMD ["yt2pod", "-dataclean"]

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ type config struct {
 	YTDataAPIKey           string    `json:"yt_data_api_key"          validate:"required"`
 	Podcasts               []podcast `json:"podcasts"                 validate:"required,dive"`
 	ServeHost              string    `json:"serve_host"               validate:"hostname"`
-	ServeUri              string    `json:"serve_uri"               validate:"uri"`
+	ServeUri               string    `json:"serve_uri"               validate:"uri"`
 	ServePort              int       `json:"serve_port"               validate:"min=1,max=65535"`
 	ServeDirectoryListings bool      `json:"serve_directory_listings" validate:"-"`
 

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ type config struct {
 	YTDataAPIKey           string    `json:"yt_data_api_key"          validate:"required"`
 	Podcasts               []podcast `json:"podcasts"                 validate:"required,dive"`
 	ServeHost              string    `json:"serve_host"               validate:"hostname"`
-	ServeUri               string    `json:"serve_uri"               validate:"uri"`
+	LinkProxy               string    `json:"link_proxy"               validate:"uri"`
 	ServePort              int       `json:"serve_port"               validate:"min=1,max=65535"`
 	ServeDirectoryListings bool      `json:"serve_directory_listings" validate:"-"`
 

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type config struct {
 	YTDataAPIKey           string    `json:"yt_data_api_key"          validate:"required"`
 	Podcasts               []podcast `json:"podcasts"                 validate:"required,dive"`
 	ServeHost              string    `json:"serve_host"               validate:"hostname"`
+	ServeUri              string    `json:"serve_uri"               validate:"uri"`
 	ServePort              int       `json:"serve_port"               validate:"min=1,max=65535"`
 	ServeDirectoryListings bool      `json:"serve_directory_listings" validate:"-"`
 

--- a/watcher.go
+++ b/watcher.go
@@ -193,8 +193,8 @@ func (w *watcher) buildURL(filePath string) string {
 		portPart = fmt.Sprintf(":%d", w.cfg.ServePort)
 	}
 
-	if w.cfg.ServeUri != "" {
-		return fmt.Sprintf("%s/%s", w.cfg.ServeUri, filePath)
+	if w.cfg.LinkProxy != "" {
+		return fmt.Sprintf("%s/%s", w.cfg.LinkProxy, filePath)
 	} else {
 		return fmt.Sprintf("http://%s%s/%s", w.cfg.ServeHost, portPart, filePath)
 	}

--- a/watcher.go
+++ b/watcher.go
@@ -193,11 +193,11 @@ func (w *watcher) buildURL(filePath string) string {
 		portPart = fmt.Sprintf(":%d", w.cfg.ServePort)
 	}
 
-       if w.cfg.ServeUri != "" {
-	return fmt.Sprintf("%s/%s", w.cfg.ServeUri, filePath)
-       } else {
-	return fmt.Sprintf("http://%s%s/%s", w.cfg.ServeHost, portPart, filePath)
-        }
+	if w.cfg.ServeUri != "" {
+		return fmt.Sprintf("%s/%s", w.cfg.ServeUri, filePath)
+	} else {
+		return fmt.Sprintf("http://%s%s/%s", w.cfg.ServeHost, portPart, filePath)
+	}
 }
 
 func (w *watcher) writeFeed() error {

--- a/watcher.go
+++ b/watcher.go
@@ -192,7 +192,12 @@ func (w *watcher) buildURL(filePath string) string {
 	if w.cfg.ServePort != 80 {
 		portPart = fmt.Sprintf(":%d", w.cfg.ServePort)
 	}
+
+       if w.cfg.ServeUri != "" {
+	return fmt.Sprintf("%s/%s", w.cfg.ServeUri, filePath)
+       } else {
 	return fmt.Sprintf("http://%s%s/%s", w.cfg.ServeHost, portPart, filePath)
+        }
 }
 
 func (w *watcher) writeFeed() error {


### PR DESCRIPTION
Hi this patch adds an optional paramater `ServeUri` where you can specify the full URI of the server rather than the automatically generated one.   I had a usecase where i was running yt2pod behind an SSL proxy and i I needed to be able to make adjustments.

This also installs ffmpeg.  youtube-dl was unable to transcode correctly until It was added.